### PR TITLE
1u0022-setup.inc: update to f444d6e (8 commits)

### DIFF
--- a/recipes-core/1u0022-setup/1u0022-setup.inc
+++ b/recipes-core/1u0022-setup/1u0022-setup.inc
@@ -3,7 +3,7 @@ LICENSE = "CLOSED"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "${@l1u0022_internal_component_uri(d, '1u0022-setup')}"
-SRCREV  = "ab5e54ede3e5b1f53239a0ce829b873584d021cc"
+SRCREV  = "f444d6e47e0a3751ff6e9fb1743d30913b0d08aa"
 
 inherit 1u0022-internal-component
 inherit features_check


### PR DESCRIPTION
f444d6e fixup! CI: use local image
6d26dab CI: use local image
f7a714a system: ensure that /boot is mounted ro
010455a factory: fix error check logic
3b81e82 factory: support download verification
798a755 factory: refactor fetch_image()
9040fcc factory: set more gpt attributes in sfdisk
aadbf83 factory:README: initial checkin