### PR TITLE
base-files: mount /boot partition

### DIFF
--- a/recipes-core/base-files/base-files/fstab.1u0022
+++ b/recipes-core/base-files/base-files/fstab.1u0022
@@ -1,2 +1,4 @@
 /dev/vg00/data	/srv	ext4	x-systemd.automount		1 1
 /srv/.data	/data	none	x-systemd.automount,bind
+
+/dev/mmcblk1p3  /boot   ext4	x-systemd.automount		1 1


### PR DESCRIPTION
This should normally be handled by systemd-gpt-auto-generator, but since we moved the root to the lvm on luks, it is not detected anymore. Remove this again when above problem is solved!