### PR TITLE
busybox: disable syslogd + klogd

### DIFF
--- a/recipes-bsp/busybox/busybox_%.bbappend
+++ b/recipes-bsp/busybox/busybox_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+## disable syslogd + klogd when systemd is used.  It steals /dev/log
+## from journald and creates an extra /var/log/messages file which
+## must be rotated manually
+
+SRC_URI:remove = "${@bb.utils.contains('DISTRO_FEATURES','systemd', 'syslog.cfg', '', d)}"
+SRC_URI += "\
+    ${@bb.utils.contains('DISTRO_FEATURES','systemd', 'file://no-syslog.cfg', '', d)} \
+"
+
+SYSTEMD_SERVICE:${PN}-syslog = ""

--- a/recipes-bsp/busybox/files/no-syslog.cfg
+++ b/recipes-bsp/busybox/files/no-syslog.cfg
@@ -1,0 +1,2 @@
+# CONFIG_SYSLOGD is not set
+# CONFIG_KLOGD is not set


### PR DESCRIPTION
Disable syslogd + klogd when systemd is used.  It steals /dev/log from journald and creates an extra /var/log/messages file which must be rotated manually

yocto-bsp#36