### PR TITLE
1u0022-setup-hostname: bind mount /etc/hostname

### DIFF
--- a/recipes-core/1u0022-setup-hostname/1u0022-setup-hostname/set_hostname.sh
+++ b/recipes-core/1u0022-setup-hostname/1u0022-setup-hostname/set_hostname.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 
+mount --bind -o ro -n /srv/hostname /etc/hostname
 exec hostname "$(cat /srv/hostname)"

--- a/recipes-core/1u0022-setup/1u0022-setup.inc
+++ b/recipes-core/1u0022-setup/1u0022-setup.inc
@@ -3,7 +3,7 @@ LICENSE = "CLOSED"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "${@l1u0022_internal_component_uri(d, '1u0022-setup')}"
-SRCREV  = "4d515d8effaf443254221f76c058d6d66ca39d02"
+SRCREV  = "b2e23af6e92d612190c0dbfa19aaa0f23d702c4f"
 
 inherit 1u0022-internal-component
 inherit features_check


### PR DESCRIPTION
NetworkManager reads /etc/hostname directly and ignores the transient hostname when sending dhcp requests.

Bind mount /srv/hostname to /etc/hostname.

https://gitlab.consolinno-it.de/leafletfirmware/1u0022-product-software/yocto-bsp/-/issues/42